### PR TITLE
Display signal layer carousel

### DIFF
--- a/app/flows/Flow_SIwave_SYZ/step_02.py
+++ b/app/flows/Flow_SIwave_SYZ/step_02.py
@@ -69,6 +69,16 @@ def run(job_path, data=None, files=None, config=None):
         if os.path.isdir(edb_dir):
             apply_xlsx(x_path, edb_dir, edb_version)
 
+            # Generate layer images for visualization
+            try:
+                edb = Edb(edb_dir, edbversion=edb_version)
+                for layer_name in edb.stackup.signal_layers:
+                    img_path = os.path.join(output_dir, f"{layer_name}.png")
+                    edb.nets.plot(layers=layer_name, save_plot=img_path)
+                edb.close()
+            except Exception:
+                pass
+
             # Create a zipped copy of the updated AEDB for easy download
             zip_path = os.path.join(output_dir, 'updated_pyedb.zip')
             if os.path.isfile(zip_path):

--- a/app/flows/Flow_SIwave_SYZ/templates/steps/step_02.html
+++ b/app/flows/Flow_SIwave_SYZ/templates/steps/step_02.html
@@ -15,5 +15,27 @@
   {% endif %}
 </form>
 
+{% if layer_images %}
+<div id="layerCarousel" class="carousel slide mt-4" data-bs-ride="carousel">
+  <div class="carousel-inner">
+    {% for img in layer_images %}
+    <div class="carousel-item {% if loop.first %}active{% endif %}">
+      <img src="{{ url_for('main.get_job_file', job_id=job_id, filename=img) }}" class="d-block w-100" alt="{{ img }}">
+      <div class="carousel-caption d-none d-md-block">
+        <h5>{{ img }}</h5>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  <button class="carousel-control-prev" type="button" data-bs-target="#layerCarousel" data-bs-slide="prev">
+    <span class="carousel-control-prev-icon"></span>
+  </button>
+  <button class="carousel-control-next" type="button" data-bs-target="#layerCarousel" data-bs-slide="next">
+    <span class="carousel-control-next-icon"></span>
+  </button>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% endif %}
+
 {# Removed directory tree display for Step 1 input/output #}
 {% endblock %}

--- a/app/routes.py
+++ b/app/routes.py
@@ -425,6 +425,8 @@ def run_step(flow_id, step, job_id):
             if os.path.isfile(os.path.join(output_dir, f)):
                 output_files.append(f)
 
+    layer_images = None
+
     info_lines = None
     nets = None
     selected_nets = None
@@ -445,6 +447,7 @@ def run_step(flow_id, step, job_id):
         if xlsx_file:
             url = url_for('main.get_job_file', job_id=job_id, filename=xlsx_file)
             info_lines.append(f'Step 1 Output: <a href="{url}" download>{xlsx_file}</a>')
+        layer_images = [f for f in output_files if f.lower().endswith('.png')]
     elif flow_id == 'Flow_SIwave_SYZ' and step == 'step_03':
         categories = {}
         renamed_map = {}
@@ -558,6 +561,7 @@ def run_step(flow_id, step, job_id):
         output_tree=output_tree,
         selected_nets=selected_nets,
         zip_file=zip_file,
+        layer_images=layer_images,
         categories=locals().get('categories'),
         renamed_map=locals().get('renamed_map'),
         error=error_msg,


### PR DESCRIPTION
## Summary
- plot each signal layer to PNG when updating the stackup
- display generated images as a Bootstrap carousel in step 2
- send layer image list from backend when rendering step 2

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875e2733458832aae745d541e683e1e