### PR TITLE
Generate layer images after step1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,8 @@ step. Upload either a `.brd` file or a zipped `.aedb` archive. The uploaded file
 is processed and saved as `design.aedb` in the job's output directory.
 
 All subsequent steps reference `output/design.aedb`, ensuring a consistent path
-regardless of the original input type.
+regardless of the original input type. When the design is uploaded and you
+click **Apply** in Step&nbsp;1, the application now plots all signal layer images
+and saves them as PNG files in the job's output directory. These images are
+displayed as a carousel on the Step&nbsp;2 page for quick visualization of the
+stackup.

--- a/app/flows/Flow_SIwave_SYZ/step_01.py
+++ b/app/flows/Flow_SIwave_SYZ/step_01.py
@@ -80,6 +80,16 @@ def run(job_path, data=None, files=None, config=None):
 
             xlsx_path = os.path.join(output_dir, "stackup.xlsx")
             export_stackup(edb, xlsx_path, unit=unit)
+
+            # Plot all signal layers for the next step carousel
+            try:
+                for layer_name in edb.stackup.signal_layers:
+                    img_path = os.path.join(output_dir, f"{layer_name}.png")
+                    edb.nets.plot(layers=[layer_name], show=False, save_plot=img_path)
+            except Exception as e:
+                with open(os.path.join(output_dir, "plot_error.log"), "a") as fp:
+                    fp.write(f"Failed to plot {layer_name}: {e}\n")
+
             edb.close()
         else:
             tmp_dir = os.path.join(input_dir, "aedb_zip")
@@ -107,4 +117,14 @@ def run(job_path, data=None, files=None, config=None):
             edb = Edb(edb_dir, edbversion=edb_version)
             xlsx_path = os.path.join(output_dir, "stackup.xlsx")
             export_stackup(edb, xlsx_path, unit=unit)
+
+            # Plot all signal layers for the next step carousel
+            try:
+                for layer_name in edb.stackup.signal_layers:
+                    img_path = os.path.join(output_dir, f"{layer_name}.png")
+                    edb.nets.plot(layers=[layer_name], show=False, save_plot=img_path)
+            except Exception as e:
+                with open(os.path.join(output_dir, "plot_error.log"), "a") as fp:
+                    fp.write(f"Failed to plot {layer_name}: {e}\n")
+
             edb.close()


### PR DESCRIPTION
## Summary
- generate signal layer PNGs in step_01
- mention carousel preview in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877119a3824832aa510a48d1206859e