### PR TITLE
Add optional PCB layout viewer

### DIFF
--- a/app/flows/Flow_SIwave_SYZ/templates/steps/step_01.html
+++ b/app/flows/Flow_SIwave_SYZ/templates/steps/step_01.html
@@ -2,6 +2,10 @@
 {% block content %}
 <h2>{{ flow_name }} - {{ job_topic }} : Step 1 - Import Design</h2>
 <form method="post" enctype="multipart/form-data" id="brd-form">
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="show-layout" name="show_layout" {% if show_layout %}checked{% endif %}>
+    <label class="form-check-label" for="show-layout">Show PCB Layout</label>
+  </div>
   <div class="mb-3">
     <label class="form-label">Design File (BRD or zipped AEDB)</label>
     <input type="file" class="form-control" name="design_file" accept=".brd,.zip,.aedb" required>

--- a/app/flows/Flow_SIwave_SYZ/templates/steps/step_02.html
+++ b/app/flows/Flow_SIwave_SYZ/templates/steps/step_02.html
@@ -28,10 +28,12 @@
     {% endfor %}
   </div>
   <button class="carousel-control-prev" type="button" data-bs-target="#layerCarousel" data-bs-slide="prev">
-    <span class="carousel-control-prev-icon"></span>
+    <span aria-hidden="true">&larr;</span>
+    <span class="visually-hidden">Previous</span>
   </button>
   <button class="carousel-control-next" type="button" data-bs-target="#layerCarousel" data-bs-slide="next">
-    <span class="carousel-control-next-icon"></span>
+    <span aria-hidden="true">&rarr;</span>
+    <span class="visually-hidden">Next</span>
   </button>
 </div>
 <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>

--- a/app/routes.py
+++ b/app/routes.py
@@ -382,8 +382,10 @@ def run_step(flow_id, step, job_id):
                 if isinstance(result, dict) and result.get('error'):
                     error_msg = result['error']
                     disable_actions = True
-        
+
         if error_msg is None:
+            if step == 'step_01':
+                meta['show_layout'] = 'show_layout' in request.form
             # Determine the next step from flow.json
             next_step = None
             flow_json = os.path.join(flow_path, 'flow.json')
@@ -447,7 +449,10 @@ def run_step(flow_id, step, job_id):
         if xlsx_file:
             url = url_for('main.get_job_file', job_id=job_id, filename=xlsx_file)
             info_lines.append(f'Step 1 Output: <a href="{url}" download>{xlsx_file}</a>')
-        layer_images = [f for f in output_files if f.lower().endswith('.png')]
+        if meta.get('show_layout'):
+            layer_images = [f for f in output_files if f.lower().endswith('.png')]
+        else:
+            layer_images = None
     elif flow_id == 'Flow_SIwave_SYZ' and step == 'step_03':
         categories = {}
         renamed_map = {}
@@ -608,6 +613,7 @@ def run_step(flow_id, step, job_id):
         selected_nets=selected_nets,
         zip_file=zip_file,
         layer_images=layer_images,
+        show_layout=meta.get('show_layout', False),
         categories=locals().get('categories'),
         part_values=locals().get("part_values"),
         renamed_map=locals().get('renamed_map'),


### PR DESCRIPTION
## Summary
- add `Show PCB Layout` checkbox for step 1
- update layout carousel arrows in step 2
- store checkbox choice in `metadata.json`
- render layout images only when option enabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687726863124832abf65f5a2c986bebf