### PR TITLE
Make layer plotting optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ is processed and saved as `design.aedb` in the job's output directory.
 
 All subsequent steps reference `output/design.aedb`, ensuring a consistent path
 regardless of the original input type. When the design is uploaded and you
-click **Apply** in Step&nbsp;1, the application now plots all signal layer images
-and saves them as PNG files in the job's output directory. These images are
-displayed as a carousel on the Step&nbsp;2 page for quick visualization of the
-stackup.
+click **Apply** in Step&nbsp;1, you can optionally generate PCB layout images for
+the next step. If the **Show PCB Layout in Step2** checkbox is selected, the
+application plots all signal layer images and saves them as PNG files in the
+job's output directory. Step&nbsp;2 displays these images in a carousel. Leaving
+the box unchecked skips image generation to speed up Step&nbsp;1.

--- a/app/flows/Flow_SIwave_SYZ/step_01.py
+++ b/app/flows/Flow_SIwave_SYZ/step_01.py
@@ -59,8 +59,10 @@ def run(job_path, data=None, files=None, config=None):
     os.makedirs(output_dir, exist_ok=True)
 
     unit = "mm"
+    show_layout = False
     if data:
         unit = data.get("unit", "mm")
+        show_layout = 'show_layout' in data
     design = files.get("design_file") if files else None
     edb_version = (config or {}).get("edb_version", "2024.1")
     if design and design.filename:
@@ -81,14 +83,15 @@ def run(job_path, data=None, files=None, config=None):
             xlsx_path = os.path.join(output_dir, "stackup.xlsx")
             export_stackup(edb, xlsx_path, unit=unit)
 
-            # Plot all signal layers for the next step carousel
-            try:
-                for layer_name in edb.stackup.signal_layers:
-                    img_path = os.path.join(output_dir, f"{layer_name}.png")
-                    edb.nets.plot(layers=[layer_name], show=False, save_plot=img_path)
-            except Exception as e:
-                with open(os.path.join(output_dir, "plot_error.log"), "a") as fp:
-                    fp.write(f"Failed to plot {layer_name}: {e}\n")
+            # Plot all signal layers only when user requests layout images
+            if show_layout:
+                try:
+                    for layer_name in edb.stackup.signal_layers:
+                        img_path = os.path.join(output_dir, f"{layer_name}.png")
+                        edb.nets.plot(layers=[layer_name], show=False, save_plot=img_path)
+                except Exception as e:
+                    with open(os.path.join(output_dir, "plot_error.log"), "a") as fp:
+                        fp.write(f"Failed to plot {layer_name}: {e}\n")
 
             edb.close()
         else:
@@ -118,13 +121,14 @@ def run(job_path, data=None, files=None, config=None):
             xlsx_path = os.path.join(output_dir, "stackup.xlsx")
             export_stackup(edb, xlsx_path, unit=unit)
 
-            # Plot all signal layers for the next step carousel
-            try:
-                for layer_name in edb.stackup.signal_layers:
-                    img_path = os.path.join(output_dir, f"{layer_name}.png")
-                    edb.nets.plot(layers=[layer_name], show=False, save_plot=img_path)
-            except Exception as e:
-                with open(os.path.join(output_dir, "plot_error.log"), "a") as fp:
-                    fp.write(f"Failed to plot {layer_name}: {e}\n")
+            # Plot all signal layers only when user requests layout images
+            if show_layout:
+                try:
+                    for layer_name in edb.stackup.signal_layers:
+                        img_path = os.path.join(output_dir, f"{layer_name}.png")
+                        edb.nets.plot(layers=[layer_name], show=False, save_plot=img_path)
+                except Exception as e:
+                    with open(os.path.join(output_dir, "plot_error.log"), "a") as fp:
+                        fp.write(f"Failed to plot {layer_name}: {e}\n")
 
             edb.close()


### PR DESCRIPTION
## Summary
- plot PCB layer images only when the `Show PCB Layout in Step2` option is checked
- document the optional behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877416b1a44832aaf37d95abde1d47c