### PR TITLE
Enable dark theme site-wide

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -17,7 +17,7 @@
     <title>{{ title if title else 'Simulation Service' }}</title>
   </head>
   <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
       <a class="navbar-brand" href="{{ url_for('main.deck') }}">Simulation Service</a>
       <div class="ms-auto">
         {% if session.get('username') %}


### PR DESCRIPTION
## Summary
- enable Bootstrap dark theme globally
- switch navbar style for dark theme

## Testing
- `python -m py_compile run.py`
- `find app -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6881d062ede4832ab55787cf95d56a3c